### PR TITLE
feat: Add keyboard shortcuts help button to TopBar

### DIFF
--- a/packages/ui/src/components/layout/TopBar.tsx
+++ b/packages/ui/src/components/layout/TopBar.tsx
@@ -1,4 +1,4 @@
-import { Settings, Bell, Zap, MessageSquare, RefreshCcw, Volume2, VolumeX, Terminal, DollarSign, ChevronDown } from 'lucide-react';
+import { Settings, Bell, Zap, MessageSquare, RefreshCcw, Volume2, VolumeX, Terminal, DollarSign, ChevronDown, HelpCircle } from 'lucide-react';
 import { useUIStore } from '../../store/uiState';
 import { useState, useEffect, useRef } from 'react';
 import { audioManager } from '../../audio/audioManager';
@@ -305,6 +305,15 @@ export function TopBar() {
           aria-pressed={settingsModalOpen}
         >
           <Settings className={`w-5 h-5 ${settingsModalOpen ? 'text-hud-green' : 'text-gray-400'}`} aria-hidden="true" />
+        </button>
+
+        Keyboard shortcuts
+        <button
+          onClick={() => window.dispatchEvent(new CustomEvent('show-shortcuts-help'))}
+          className="p-2 hover:bg-command-accent rounded transition-colors"
+          aria-label="Keyboard shortcuts"
+        >
+          <HelpCircle className="w-5 h-5 text-gray-400" aria-hidden="true" />
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

Close #65 

## Changes
Help entry point in TopBar: added a small ? (HelpCircle) icon button after the Settings gear. A click dispatches the existing show-shortcuts-help event so the keyboard shortcuts modal (still rendered in App) opens. Closing stays as before via Escape or the modal’s close (X) button. Styling matches the other TopBar controls.

## Type

<!-- Check the relevant box -->

- [ YES] New feature


## Testing

<!-- How did you test this? -->

- [ YES] Tested the specific feature/fix manually


## Checklist

- [ YES] Code follows existing patterns in the codebase
- [YES ] No secrets or API keys committed
