### PR TITLE
fix(security): add brace-expansion >=5.0.6 override (closes alert #50)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   path-to-regexp: ^0.1.13
   socket.io-parser: ^4.2.6
   undici: ^7.24.0
+  brace-expansion: ^5.0.6
 
 importers:
 
@@ -1413,8 +1414,8 @@ packages:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5075,7 +5076,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6674,7 +6675,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ overrides:
   path-to-regexp: '^0.1.13'
   socket.io-parser: '^4.2.6'
   undici: '^7.24.0'
+  brace-expansion: '^5.0.6'
 
 allowBuilds:
   '@prisma/client': true


### PR DESCRIPTION
## Summary

Closes Dependabot alert **#50** (medium, disclosed 2026-05-18):
*"brace-expansion: Large numeric range defeats documented `max` DoS protection"*
(vulnerable range `>=5.0.0 <5.0.6`).

The package landed in our lockfile at 5.0.5 via #183's dev-dependencies group
bump earlier today. Adding a single `brace-expansion: '^5.0.6'` line to
`pnpm-workspace.yaml` overrides resolves it across the whole workspace.

## Test plan

- [x] `pnpm install` clean (806 entries pass supply-chain policy)
- [x] `brace-expansion@5.0.6` confirmed in `pnpm-lock.yaml` (was 5.0.5)
- [ ] CI green on this PR
