### PR TITLE
docs: record 2026-05-18 security sweep + SECURITY.md policy refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Agent Battle Command Center.
 
 ---
 
+## [v0.11.x security sweep] - 2026-05-18
+
+Second maintenance pass since v0.11.0 settled. Focus: drain the Dependabot backlog that the April triage policy had left "acknowledged but not chased", incorporate a fresh-disclosed brace-expansion advisory, and tidy the issue tracker for a new external contributor.
+
+### Security
+
+- **Dependabot alerts: 12 → 0.** Code-scanning alerts: 3 → 0. All four high-severity transitives the April policy had deferred (lodash, path-to-regexp, socket.io-parser, undici) are now resolved via pnpm overrides; @anthropic-ai/sdk medium-sev advisory closed via direct bump.
+- **pnpm overrides migrated to `pnpm-workspace.yaml`.** The `pnpm.overrides` block in root `package.json` was being **silently ignored** by pnpm 11 (which the repo runs locally and in CI) — pnpm 10+ moved overrides to `pnpm-workspace.yaml`. The April overrides (esbuild, minimatch, handlebars) had survived only by lockfile inertia; any genuine re-resolve would have dropped them. Migration commit also bumps `engines.pnpm` floor `>=8.0.0` → `>=10.0.0` and sets `allowBuilds` for the four trusted postinstalls (esbuild, prisma, @prisma/client, @prisma/engines).
+- **New overrides added** alongside the migration:
+  - `lodash` 4.17.23 → **4.18.1** (closes alerts #38 high, #39 medium)
+  - `path-to-regexp` 0.1.12 → **0.1.13** (closes #32 high, CVE-2026-4867)
+  - `socket.io-parser` 4.2.5 → **4.2.6** (closes #17 high, CVE-2026-33151)
+  - `undici` 7.22.0 → **7.25.0** (closes #15 high)
+  - `brace-expansion` 5.0.5 → **5.0.6** (closes #50 medium — disclosed 2026-05-18, landed within hours; CVE-2026-… see GHSA)
+- **`@anthropic-ai/sdk` bumped** in `packages/api`: `^0.90.0` → `^0.91.1` via the security PR (closes alerts #47/#48 medium — Filesystem Memory Tool file permissions), then onward to `^0.96.0` via the prod-deps Dependabot group.
+- **Python deps in `packages/agents` refreshed** alongside the JS work: anthropic ≥0.97.0, langchain-anthropic ≥0.3.22, httpx ≥0.28.1, pydantic ≥2.13.3, fastapi 0.136.1.
+- Landed across PRs **#185** (overrides + SDK), **#186** (prod-deps grouped), **#187** (brace-expansion), **#183** (dev-deps grouped including @types/node, rollup, vite, vitest, tailwindcss, three.js types), plus 5 Python Dependabot merges (#166–#171). 5 individual Dependabot PRs closed as subsets of the grouped ones (#173, #178, #179, #180, #181).
+
+### Documentation
+
+- **SECURITY.md triage policy rewritten.** The April-era "build-time / dev-only transitives — acknowledged but not chased" stance is replaced by the reality of the May sweep: those transitives are now actively chased via overrides, the alert count is genuinely zero, and the policy reflects the bar going forward.
+- **SECURITY.md Known Vulnerabilities section refreshed** with the May resolutions; outdated "pnpm.overrides in package.json" references corrected to point at `pnpm-workspace.yaml`.
+
+### Community
+
+- **Phase 3.6 Small Polish Roadmap** opened as tracking issue **#189**. 10 individual small-polish issues consolidated into the checklist (#41, #54, #59, #68, #69, #74, #75, #76, #77, #87) — same pattern as the earlier #119/#120 consolidations. Issue #53 (dark/light theme toggle) closed separately as already implemented (the existing `packages/ui/src/components/layout/ThemeSelector.tsx` covers it).
+- **First external contributor onboarded.** @Bawazier offered to take **#57 (Export task results as CSV/JSON)** with a Fridays-only cadence; issue assigned, with maintainer pointers added to the body (per-resource routes in `packages/api/src/routes/`, json2csv + streaming for large queries, Dashboard modal precedent).
+
+---
+
 ## [v0.11.x maintenance pass] - 2026-04-23
 
 Portfolio-hygiene sweep as the repo settled into stable-maintenance mode. No feature work — documentation, security, and housekeeping only.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -225,32 +225,41 @@ If you're deploying Agent Battle Command Center, **follow these practices:**
 
 ## Dependency Scanner Advisories
 
-GitHub's Dependabot flags advisories in both runtime and build-time dependencies, including transitives of dev tooling (Jest, Vitest, ESLint, Storybook, etc.). Triage policy for this repo in its stable-maintenance phase:
+GitHub's Dependabot flags advisories in both runtime and build-time dependencies, including transitives of dev tooling (Jest, Vitest, ESLint, Storybook, etc.). Triage policy for this repo:
 
-- **Runtime CRITICAL / HIGH** — fixed promptly via direct bumps or `pnpm.overrides`.
-- **Runtime MEDIUM / LOW** — fixed when a dependency naturally bumps; not chased individually.
-- **Build-time / dev-only transitives** — acknowledged but not chased. They don't affect users of the deployed app, and rewriting the dev tree is out of scope for maintenance mode. The public Dependabot count reflects this backlog.
+- **Runtime CRITICAL / HIGH** — fixed promptly via direct bumps or pnpm overrides in `pnpm-workspace.yaml`.
+- **Runtime MEDIUM / LOW** — fixed when a dependency naturally bumps; addressed in periodic sweeps when accumulated.
+- **Build-time / dev-only transitives** — also fixed via overrides where Dependabot doesn't have a direct path. The May 2026 sweep cleared the entire transitive backlog this way; the bar going forward is **zero open alerts** at the end of each sweep cycle.
 
-If you believe a flagged alert actually reaches runtime code (not dev tooling), please report it as a vulnerability via the private advisory flow above — that reframes it as a supported-scope issue and gets fixed.
+> **Override location.** Overrides live in `pnpm-workspace.yaml` (the v10+ home for that setting). The `pnpm.overrides` block in `package.json` is **silently ignored** by pnpm 10+ — earlier maintenance docs that referenced that location were inaccurate by the time the repo upgraded.
+
+If you believe a flagged alert reaches runtime code, please report it as a vulnerability via the private advisory flow above — that reframes it as a supported-scope issue and gets fixed.
 
 For the active successor project with a fresher, continuously-maintained dep tree, see [claudette](https://github.com/mrdushidush/claudette).
 
 ## Known Vulnerabilities
 
-### Current (v0.11.x, as of April 2026)
+### Current (v0.11.x, as of May 2026)
 
-Resolved via `pnpm.overrides` in root `package.json`:
+**Open alerts: 0** (verified post-sweep 2026-05-18). The full Dependabot and code-scanning alert lists are empty for both runtime and dev/transitive dependencies.
 
-- **handlebars** (CRITICAL GHSA — JS injection via AST type confusion) — forced to `>=4.7.9` in the lockfile.
-- **esbuild**, **minimatch** — forced to safe versions (prior polish passes).
+Resolved via overrides in `pnpm-workspace.yaml`:
 
-Residual transitive alerts remaining in the Dependabot backlog, per the triage policy above:
+- **handlebars** (CRITICAL GHSA — JS injection via AST type confusion) — forced to `>=4.7.9`.
+- **esbuild** `>=0.27.2`, **minimatch** `>=10.2.3` (prior polish passes).
+- **lodash** `^4.18.0` — closes prototype-pollution (`_.unset`/`_.omit`) and `_.template` code-injection advisories. *(May 2026 sweep.)*
+- **path-to-regexp** `^0.1.13` — closes ReDoS via malformed URL parameters (CVE-2026-4867). *(May 2026 sweep.)*
+- **socket.io-parser** `^4.2.6` — closes excessive-buffering DoS (CVE-2026-33151). *(May 2026 sweep.)*
+- **undici** `^7.24.0` — closes WebSocket `server_max_window_bits` validation crash. *(May 2026 sweep.)*
+- **brace-expansion** `^5.0.6` — closes `max`-protection bypass DoS, disclosed and patched same day. *(May 2026 sweep.)*
 
-- `lodash`, `undici`, `picomatch`, `flatted`, `socket.io-parser`, `brace-expansion` — transitives of dev/build tooling (Jest, Vitest, Storybook variants). Not reachable from runtime code paths.
+Resolved via direct dependency bumps:
 
-Resolved in the v0.11.x maintenance pass (April 2026):
+- **@anthropic-ai/sdk** — bumped `^0.90.0` → `^0.91.1` (security floor) → `^0.96.0` (latest) in `packages/api/package.json`. Closes the "Insecure Default File Permissions in Local Filesystem Memory Tool" advisory. *(May 2026 sweep.)*
 
-- `uuid` — removed entirely from `packages/api/package.json`; was a declared direct dep but never imported in source (the only "uuid" references were Zod's `z.string().uuid()` validator, which has no uuid-package dependency). Closed 2 Dependabot alerts.
+### Past resolutions
+
+- `uuid` — removed entirely from `packages/api/package.json` in the **April 2026 maintenance pass**; was declared as a direct dep but never imported (the only "uuid" references were Zod's `z.string().uuid()` validator, which has no uuid-package dependency). Closed 2 Dependabot alerts.
 
 ### Historical
 
@@ -312,5 +321,5 @@ We thank the following security researchers who have responsibly disclosed vulne
 
 This security policy is subject to change without notice. By using Agent Battle Command Center, you agree to follow responsible disclosure practices.
 
-**Last Updated**: 2026-04-23
-**Policy Version**: 1.1 (maintenance-mode triage + stable-status framing)
+**Last Updated**: 2026-05-18
+**Policy Version**: 1.2 (transitive overrides actively maintained; overrides home corrected to `pnpm-workspace.yaml`; zero-alert bar codified)


### PR DESCRIPTION
## Summary

Records the 2026-05-18 security sweep in CHANGELOG and refreshes SECURITY.md so the triage policy reflects what actually shipped today (rather than the April-era "acknowledged but not chased" stance, which no longer matches reality).

## What changed

**CHANGELOG.md** — new top entry `[v0.11.x security sweep] - 2026-05-18` covering:
- The 3 security PRs landed today (#185 transitive overrides + SDK floor, #186 prod-deps grouped including SDK to `^0.96.0`, #187 brace-expansion `^5.0.6` for the same-day disclosure).
- The 5 Python merges (#166–#171, includes anthropic 0.97+, langchain-anthropic 0.3.22+, httpx 0.28+, pydantic 2.13.3+, fastapi 0.136.1).
- The grouped dev-deps merge #183 and the 5 redundant individual closures (#173, #178, #179, #180, #181).
- The pnpm v10+ overrides migration (out of dead `pnpm.overrides` block in `package.json`, into `pnpm-workspace.yaml`) and the engines.pnpm floor bump.
- Issue-tracker consolidation: #189 Phase 3.6 Small Polish roadmap absorbs 10 small-polish issues; #53 closed as already implemented; #57 assigned to first external contributor @Bawazier.

**SECURITY.md** — three updates:
- Triage policy: dev-only transitives are now actively chased via overrides; bar going forward is **zero open alerts** per cycle.
- Known Vulnerabilities: refreshed to "open alerts: 0" with the May resolutions listed individually (lodash, path-to-regexp, socket.io-parser, undici, brace-expansion, @anthropic-ai/sdk).
- Override-home callout: pnpm 10+ silently ignores `pnpm.overrides` in `package.json` — overrides live in `pnpm-workspace.yaml` and the doc now says so explicitly.
- Policy version 1.1 → 1.2; Last Updated 2026-04-23 → 2026-05-18.

## Test plan

- [x] CHANGELOG renders cleanly (new entry above the April entry; date and version match the file's existing format).
- [x] SECURITY.md sections still in the original order; only the three targeted blocks rewritten.
- [x] No code changes — docs-only.
- [ ] CI green on this PR.
