### PR TITLE
fix: classify import failures as import_error, not runtime_error

### DIFF
--- a/packages/api/src/services/__tests__/complexityCalculator.test.ts
+++ b/packages/api/src/services/__tests__/complexityCalculator.test.ts
@@ -154,6 +154,34 @@ describe('Complexity Calculator', () => {
       expect(categorizeError(task, createLogs(2))).toBe('import_error');
     });
 
+    it('should categorize a Python ImportError as an import error', () => {
+      // 'ImportError:' also contains the 'error:' substring the runtime branch
+      // matches on. This passes only while the import branch is checked first.
+      const task = createTask({
+        status: 'failed',
+        error: 'ImportError: cannot import name foo',
+      });
+      expect(categorizeError(task, createLogs(2))).toBe('import_error');
+    });
+
+    it('should categorize a Python ModuleNotFoundError as an import error', () => {
+      // Matches none of the older patterns - 'module not found' is not a
+      // substring of 'ModuleNotFoundError: No module named x'.
+      const task = createTask({
+        status: 'failed',
+        error: 'ModuleNotFoundError: No module named requests',
+      });
+      expect(categorizeError(task, createLogs(2))).toBe('import_error');
+    });
+
+    it('should categorize a Node module resolution failure as an import error', () => {
+      const task = createTask({
+        status: 'failed',
+        error: 'Error: Cannot find module express',
+      });
+      expect(categorizeError(task, createLogs(2))).toBe('import_error');
+    });
+
     it('should categorize denied access as a permission error', () => {
       const task = createTask({ status: 'failed', error: 'Access denied to workspace' });
       expect(categorizeError(task, createLogs(2))).toBe('permission_error');

--- a/packages/api/src/services/complexityCalculator.ts
+++ b/packages/api/src/services/complexityCalculator.ts
@@ -104,6 +104,22 @@ export function categorizeError(task: Task, logs: ExecutionLog[]): string | null
     return 'syntax_error';
   }
 
+  // Check for file/import errors
+  //
+  // This MUST stay above the runtime-error branch. Python spells import
+  // failures `ImportError:` and `ModuleNotFoundError:`, and Node spells its
+  // own `Error: Cannot find module` — all three contain the `'error:'`
+  // substring the runtime branch matches on, so ordering it second made this
+  // branch unreachable for every real import failure.
+  if (
+    errorMsg.includes('import') ||
+    errorMsg.includes('module not found') ||
+    errorMsg.includes('no module named') ||
+    errorMsg.includes('cannot find module')
+  ) {
+    return 'import_error';
+  }
+
   // Check for runtime errors
   if (
     errorMsg.includes('runtime error') ||
@@ -111,11 +127,6 @@ export function categorizeError(task: Task, logs: ExecutionLog[]): string | null
     errorMsg.includes('error:')
   ) {
     return 'runtime_error';
-  }
-
-  // Check for file/import errors
-  if (errorMsg.includes('import') || errorMsg.includes('module not found')) {
-    return 'import_error';
   }
 
   // Check for permission errors


### PR DESCRIPTION
`categorizeError()` tested its runtime-error branch before its import branch. That branch matches on the bare substring `'error:'`, and **every** import failure our runtimes emit contains it:

| input | before | after |
|---|---|---|
| `ImportError: cannot import name foo` | `runtime_error` ❌ | `import_error` ✅ |
| `ModuleNotFoundError: No module named requests` | `runtime_error` ❌ | `import_error` ✅ |
| `Error: Cannot find module express` | `runtime_error` ❌ | `import_error` ✅ |

So the import branch was effectively dead code. The only input that ever reached it was the exact phrase `module not found` — which no runtime actually prints. Python says `No module named x`, Node says `Cannot find module x`.

### Changes

Both in one hunk of `packages/api/src/services/complexityCalculator.ts`:

1. **The import branch moves above the runtime branch.** A comment marks the ordering as load-bearing so it doesn't get "tidied" back later.
2. **It learns the two spellings runtimes actually emit** — `no module named` and `cannot find module`. Without these the reorder alone still misses `ModuleNotFoundError`, the single most common import failure in this repo since the agents execute Python tasks.

### Blast radius: data, not control flow

The returned string is consumed in exactly one place — `taskExecutor.ts:289` writes it to `Task.errorCategory` — and nothing branches on its value. This changes what gets *recorded* for a failed task, not what the system *does* next.

### Test power measured, not assumed

Each production change was reverted on its own and the suite re-run:

| reverted change | tests turned red |
|---|---|
| import branch moved back below runtime | 3 (all the new ones) |
| drop `no module named` | **exactly 1** |
| drop `cannot find module` | **exactly 1** |

The pre-existing `'should categorize an exception as a runtime error'` test stayed green through all three reverts — that's what proves the runtime branch still works after being moved down.

⚠️ Do not delete any of the three new tests as redundant. Two of them are the only coverage their respective pattern has.

### Verification

- `corepack pnpm -r lint` → exit 0
- `corepack pnpm -r --workspace-concurrency=1 test` → api **241/241 in 16 suites** (was 238/16) · ui **53/53** unchanged
- `corepack pnpm -r build` → exit 0

Follow-up to #216, which deliberately left this behaviour untested so a fix wouldn't be cemented — those characterization tests are what made this change safe to make.

> **Note:** the `Security Scan` check is red on `main` itself (`pnpm audit --prod --audit-level=high`, 3 runtime highs: `ws` <8.21.0, `engine.io` <6.6.7, `socket.io-parser` <4.2.7). Pre-existing, not from this PR — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
