### PR TITLE
test: revive the 9 auth-middleware tests that never ran

### DIFF
--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -10,7 +10,7 @@ export default {
     '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
   },
   roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  testMatch: ['**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts', '!src/__mocks__/**'],
   // Coverage thresholds disabled for initial setup; focus on tested services
   // coverageThreshold: {

--- a/packages/api/src/middleware/auth.test.ts
+++ b/packages/api/src/middleware/auth.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { Request, Response, NextFunction } from 'express';
-import { requireApiKey, optionalApiKey } from './auth.js';
+import type { Request, Response, NextFunction } from 'express';
 
-// Mock config
-jest.mock('../config.js', () => ({
+// This package is ESM ("type": "module" + extensionsToTreatAsEsm). `jest.mock`
+// is not hoisted for ES modules and silently does nothing - which is why these
+// tests were dead weight even once collected: `config.auth.apiKey` stayed
+// undefined and every request took the "not configured" 500 branch.
+// `unstable_mockModule` + a dynamic import is the ESM equivalent, and the
+// import must happen after the mock is registered.
+jest.unstable_mockModule('../config.js', () => ({
   config: {
     auth: {
       apiKey: 'test-api-key-12345',
     },
   },
 }));
+
+const { requireApiKey, optionalApiKey } = await import('./auth.js');
 
 describe('Auth Middleware', () => {
   let mockRequest: Partial<Request>;
@@ -25,13 +31,13 @@ describe('Auth Middleware', () => {
     mockResponse = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn().mockReturnThis(),
-    };
+    } as unknown as Partial<Response>;
     nextFunction = jest.fn();
   });
 
   describe('requireApiKey', () => {
     it('should allow health check without API key', () => {
-      mockRequest.path = '/health';
+      mockRequest = { headers: {}, query: {}, path: '/health' };
 
       requireApiKey(
         mockRequest as Request,
@@ -88,7 +94,10 @@ describe('Auth Middleware', () => {
       expect(mockResponse.status).not.toHaveBeenCalled();
     });
 
-    it('should allow requests with valid API key in query param', () => {
+    it('should not accept an API key from the query param', () => {
+      // Query-param auth was removed deliberately: keys in a URL leak into
+      // access logs, Referer headers and browser history. Only X-API-Key is
+      // honoured, so a request carrying the correct key here is still 401.
       mockRequest.query = { api_key: 'test-api-key-12345' };
 
       requireApiKey(
@@ -97,11 +106,11 @@ describe('Auth Middleware', () => {
         nextFunction
       );
 
-      expect(nextFunction).toHaveBeenCalled();
-      expect(mockResponse.status).not.toHaveBeenCalled();
+      expect(mockResponse.status).toHaveBeenCalledWith(401);
+      expect(nextFunction).not.toHaveBeenCalled();
     });
 
-    it('should prefer header over query param', () => {
+    it('should authenticate from the header and ignore the query param', () => {
       mockRequest.headers = { 'x-api-key': 'test-api-key-12345' };
       mockRequest.query = { api_key: 'wrong-key' };
 


### PR DESCRIPTION
`packages/api/src/middleware/auth.test.ts` has held 9 tests for `requireApiKey` and `optionalApiKey` since it was written. **None of them had ever executed.**

`jest.config.js` matched only `**/__tests__/**/*.test.ts`, and this file lives in `src/middleware/` — the only test file in the package outside a `__tests__/` directory. Jest reported a full green suite while the API-key check guarding every credit-spending endpoint sat at 0% coverage. The tell was in the coverage table, which listed the *test file itself* as uncovered source.

### Collecting the file was not enough

Three further faults had to be fixed before a single test could pass. Each was found by applying the change and running it, not by reading:

**1. It did not compile.** `jest.fn().mockReturnThis()` is `Mock<UnknownFunction>` and satisfies neither `Response['status']` nor `Send<...>` (TS2322 ×2), and `Request.path` is read-only, so `mockRequest.path = '/health'` is TS2540. Enabling `testMatch` alone turns the suite red.

**2. The config mock did nothing.** This package is ESM, and **`jest.mock` is not hoisted for ES modules — it is a silent no-op.** With the mock inert, `config.auth.apiKey` stayed `undefined` and every request took the "API key not configured" 500 branch:

```
● should reject requests without API key
  Expected: 401
  Received: 500
```

6 of 9 failed that way. The 3 that passed were exactly the ones that never read config. Replaced with `jest.unstable_mockModule` + a dynamic `await import('./auth.js')`.

> ⚠️ The same latent problem exists in `budgetService.test.ts`. This commit establishes the pattern for fixing it separately.

**3. One test asserted removed behaviour.** `requireApiKey` reads only the `x-api-key` header (`auth.ts:27`) — the `api_key` query parameter is gone, correctly, since keys in a URL leak into access logs, `Referer` headers and browser history. That test now pins the **current security property** (a correct key supplied only via the query string is still rejected 401) rather than the removed one, and the misleadingly-named `should prefer header over query param` becomes `should authenticate from the header and ignore the query param`.

⛔ **No production file was modified.** `auth.ts` is characterised, not changed. Its stale doc comment still advertises the query param — deliberately left for a separate commit so this one stays test-only.

### Test power measured, not assumed

There is no production change to revert, so power was measured by injecting 8 faults into `auth.ts`, one at a time:

| fault injected | caught by |
|---|---|
| `/health` bypass removed | 1 test |
| 401 → 400 on missing key | 2 tests |
| 403 → 400 on invalid key | 1 test |
| invalid-key guard disabled | 1 test |
| **query-param auth re-introduced** | **1 test** |
| `safeEqual` returns true on length mismatch | 2 tests |
| `optionalApiKey` always authenticated | 2 tests |
| missing-config 500 guard removed | **`tsc` only** |

**7 of 8 caught by a test assertion.** The eighth is caught only by the type checker — removing the guard leaves `expectedKey` as `string | undefined` at the `safeEqual` call, so the suite fails to compile rather than failing an assertion. It is still caught by the gate, but it is **not** test coverage, and no test was added to fake it.

### Verification

- `corepack pnpm -r lint` → exit 0
- `corepack pnpm -r --workspace-concurrency=1 test` → api **247/247 in 17 suites** (was 238/238 in 16), ui **53/53** unchanged
- `corepack pnpm -r build` → exit 0

247 = 238 + the 9 revived tests. 17 suites = 16 + `auth.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
