### PR TITLE
fix(ui): use the R3F frame delta instead of clock.getDelta()

### DIFF
--- a/packages/ui/src/components/battlefield/AgentSquad.tsx
+++ b/packages/ui/src/components/battlefield/AgentSquad.tsx
@@ -27,10 +27,8 @@ export function AgentSquad({ squad }: AgentSquadProps) {
     [],
   );
 
-  useFrame(({ clock }) => {
+  useFrame(({ clock }, dt) => {
     if (!groupRef.current) return;
-
-    const dt = clock.getDelta();
 
     // Lerp movement toward target (2s travel time)
     if (moveProgress.current < 1) {

--- a/packages/ui/src/components/battlefield/BuildingExplosion.tsx
+++ b/packages/ui/src/components/battlefield/BuildingExplosion.tsx
@@ -54,9 +54,8 @@ export function BuildingExplosion({ task, position, success, onComplete }: Build
     };
   }, [geometries]);
 
-  useFrame(({ clock }) => {
+  useFrame((_state, dt) => {
     if (done || !groupRef.current) return;
-    const dt = clock.getDelta();
 
     progressRef.current += dt / duration;
     const p = Math.min(progressRef.current, 1);

--- a/packages/ui/src/components/battlefield/ProjectileSystem.tsx
+++ b/packages/ui/src/components/battlefield/ProjectileSystem.tsx
@@ -138,10 +138,9 @@ export function ProjectileSystem({ squads, buildings }: ProjectileSystemProps) {
     }
   }, [colorArray, trailColorArray]);
 
-  useFrame(({ clock }) => {
+  useFrame(({ clock }, dt) => {
     if (!meshRef.current) return;
     const t = clock.elapsedTime;
-    const dt = clock.getDelta();
 
     const firingSquads = squads.filter((s) => s.firing);
 
@@ -361,9 +360,8 @@ function ImpactParticles({
     }
   }, [impactColorArray, flashColorArray]);
 
-  useFrame(({ clock }) => {
+  useFrame((_state, dt) => {
     if (!meshRef.current) return;
-    const dt = clock.getDelta();
 
     // Age and move particles
     particlesRef.current = particlesRef.current.filter((p) => {

--- a/packages/ui/src/components/battlefield/TaskBuilding.tsx
+++ b/packages/ui/src/components/battlefield/TaskBuilding.tsx
@@ -152,10 +152,9 @@ export function TaskBuilding({ building }: TaskBuildingProps) {
   };
 
   // Animation loop
-  useFrame(({ clock }) => {
+  useFrame(({ clock }, dt) => {
     if (!groupRef.current) return;
 
-    const dt = clock.getDelta();
     const t = clock.elapsedTime;
 
     // Entry animation: rise from ground


### PR DESCRIPTION
Five `useFrame` callbacks across four `battlefield/` components called `clock.getDelta()` inside the callback. R3F already consumes the delta once per frame and passes it as the **second callback argument**:

```js
// @react-three/fiber@9.6.1, dist/events-b389eeca.esm.js:16043
function update(timestamp, state, frame) {
  let delta = state.clock.getDelta();
  ...
  subscription.ref.current(subscription.store.getState(), delta, frame);
}
```

`THREE.Clock.getDelta()` is destructive (`oldTime = now`), so a second call inside a callback measures only the time since R3F's own call — sub-millisecond, ~160x too small.

### User-visible consequence

`ProjectileSystem` advances `proj.progress += dt * PROJECTILE_SPEED` and only frees a slot at `progress >= 1`. At that delta projectiles never retire, the 50-slot pool saturates, `find((p) => !p.active)` returns `undefined`, and **squads stop firing permanently** — silently. Squad movement, building entry animation and particle ageing were degraded the same way.

### The change

Take `dt` from the second parameter; delete the `clock.getDelta()` line. No downstream arithmetic changed. Where `clock.elapsedTime` was still read the destructure stays; in the two callbacks where it was not, the parameter is `_state` — `packages/ui/tsconfig.json` sets `noUnusedLocals` and `noUnusedParameters`, so an unused `clock` binding fails `tsc`.

5 insertions, 11 deletions, 4 files.

### ⚠️ Test power: none, and none faked

Measured, not assumed: the suite was run with the bug present and with the fix applied — **both 250/250 green**. No test exercises any `battlefield/` component (the five `@abcc/ui` test files are `AgentCard`, `AnimatedCounter`, `ErrorBoundary`, `StatusBadge`, `TaskCard`), so re-injecting the fault leaves the suite green.

Covering this needs `@react-three/test-renderer`, which is not a dependency; a source-grep assertion would be a gimmick, not coverage. No test was added to paper over it. The gate does catch the signature change itself (dropping the `_state` underscore fails `tsc`). The correctness argument rests on the R3F source above.

### Verified

- `corepack pnpm -r lint` → exit 0
- `corepack pnpm -r --workspace-concurrency=1 test` → api **250/250 in 17 suites**, ui **53/53** — both unchanged, as expected for a card that adds no tests
- `corepack pnpm -r build` → exit 0
- `grep -rn "clock.getDelta()" packages/ui/src` → no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)