### PR TITLE
test: replace the vacuous isWarning budget test with two that assert

### DIFF
--- a/packages/api/src/services/__tests__/budgetService.test.ts
+++ b/packages/api/src/services/__tests__/budgetService.test.ts
@@ -106,16 +106,27 @@ describe('BudgetService', () => {
       expect(status.dailyLimitCents).toBe(500);
     });
 
-    it('should show warning at threshold', () => {
+    it('should warn between the threshold and the limit', () => {
       budgetService.setConfig({ dailyLimitCents: 100, warningThreshold: 0.5, enabled: true });
-      // Record 60% of budget
+      // Haiku: (200_000/1M)*100 = 20c input + (100_000/1M)*500 = 50c output = 70c of a 100c limit
+      budgetService.recordUsage(200000, 100000, 'claude-haiku-4-5');
+
+      const status = budgetService.getStatus();
+      expect(status.dailySpentCents).toBe(70);
+      expect(status.percentUsed).toBeCloseTo(0.7);
+      expect(status.isWarning).toBe(true);
+      expect(status.isOverBudget).toBe(false);
+    });
+
+    it('should stop warning once the limit is exceeded', () => {
+      budgetService.setConfig({ dailyLimitCents: 100, warningThreshold: 0.5, enabled: true });
+      // 700c against a 100c limit - past the limit, not merely past the threshold
       budgetService.recordUsage(2000000, 1000000, 'claude-haiku-4-5');
 
       const status = budgetService.getStatus();
-      // Cost should be material enough to trigger warning at 50% threshold
-      if (status.percentUsed >= 0.5 && status.percentUsed < 1) {
-        expect(status.isWarning).toBe(true);
-      }
+      expect(status.percentUsed).toBeCloseTo(7);
+      expect(status.isOverBudget).toBe(true);
+      expect(status.isWarning).toBe(false);
     });
   });
 


### PR DESCRIPTION
`budgetService.test.ts`'s "should show warning at threshold" test **ran zero assertions** and always passed.

```ts
budgetService.setConfig({ dailyLimitCents: 100, warningThreshold: 0.5, ... });
// Record 60% of budget
budgetService.recordUsage(2000000, 1000000, 'claude-haiku-4-5');

const status = budgetService.getStatus();
if (status.percentUsed >= 0.5 && status.percentUsed < 1) {   // <- never true
  expect(status.isWarning).toBe(true);                        // <- never ran
}
```

The comment claims 60% of budget; the fixture does not produce it. Haiku bills `{ input: 100, output: 500 }` cents/M, so 2M in + 1M out = 200c + 500c = **700c** against a 100c limit → `percentUsed` is **7.0**, not 0.6. That fails the `< 1` arm, so the body never executed.

`isWarning` is a conjunction — `percentUsed >= warningThreshold && percentUsed < 1` — and neither half was covered anywhere in the suite.

### The change

Two real tests replace the one vacuous one:

- **`should warn between the threshold and the limit`** — 200_000/100_000 tokens = 20c + 50c = **70c of a 100c limit**, the only window where `isWarning` is true.
- **`should stop warning once the limit is exceeded`** — deliberately reuses the original 2M/1M fixture (700c, 7.0), the case the old test was accidentally sitting on. It now pins the upper bound the `< 1` conjunct exists to enforce.

No production file modified — `budgetService.ts` is characterised, not changed.

### Power measured, not assumed

Four single-point mutations of `budgetService.ts`, run against the old test file and the new one:

| mutation of `budgetService.ts` | before | after |
|---|---|---|
| `isWarning: false` | 15 passed — **undetected** | 1 failed — caught |
| drop the `&& percentUsed < 1` conjunct | 15 passed — **undetected** | 1 failed — caught |
| `isOverBudget: percentUsed >= 100` | 15 passed — **undetected** | 1 failed — caught |
| haiku `output: 500` → `400` | 15 passed — **undetected** | 2 failed — caught |

**4/4 previously invisible, 4/4 caught now.** Neither test is redundant: the first covers the lower bound and the cost arithmetic, the second the upper bound. Removing either returns a row to "undetected".

### Verified

- `corepack pnpm -r lint` → exit 0
- `corepack pnpm -r --workspace-concurrency=1 test` → api **251/251 in 17 suites** (was 250/250), ui **53/53** unchanged
- `corepack pnpm -r build` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)