### PR TITLE
docs: replace the 88% -> 98% retry claim with both runs and their provenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Rest delays between tasks prevent context pollution (syntax errors after consecu
 
 Validates task output using `validationCommand`, retries with error context on failure.
 Pipeline: FAIL → Phase 1 (Ollama retry) → Phase 2 (Remote Ollama) → Phase 3 (Haiku escalation).
-Result: **88% raw → 98% with auto-retry (35/40 → 39/40)** on the 40-task C1-C9 stress benchmark. Canonical source: `scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md`.
+⚠️ The pipeline's effect on pass rate is **UNMEASURED**. `scripts/ollama-stress-test-40.js` runs each task exactly once with no retries, so neither the 88% (35/40, 2026-02-05, `scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md`) nor the 98% (39/40, 2026-02-20, `scripts/ollama-stress-results-40.json`) exercised it. Do not cite either number as evidence for auto-retry.
 
 **Files:** `autoRetryService.ts` (core), `main.py` (`POST /run-validation`)
 **Config:** `AUTO_RETRY_ENABLED`, `AUTO_RETRY_MAX_OLLAMA_RETRIES=1`, `AUTO_RETRY_MAX_REMOTE_RETRIES=1`, `AUTO_RETRY_MAX_HAIKU_RETRIES=1`, `AUTO_RETRY_VALIDATION_TIMEOUT_MS=15000`
@@ -365,7 +365,7 @@ Keep disabled until specific memory/context features are needed.
 
 ### Phase 2: Tier System Refinement (COMPLETED Feb 2026)
 
-**Best Results:** 98% pass rate (39/40) C1-C9 with auto-retry, 12s avg/task.
+**Best Results:** 98% single-pass (39/40) C1-C9 on 2026-02-20, 32.7s avg/task; the 2026-02-05 run scored 88% (35/40) at 54.4s avg. Neither run used auto-retry.
 - 7b is optimal for RTX 3060 Ti (14B: 40%, 30B MoE: 90% but too slow on 8GB VRAM)
 - Key optimizations: 16K context, CodeX-7 backstory, rest delays, periodic memory reset
 - Reports in `scripts/QWEN25_CODER_7B_*.md`, `scripts/QWEN3_30B_vs_7B_COMPARISON.md`
@@ -391,7 +391,7 @@ Keep disabled until specific memory/context features are needed.
 
 ### Phase 4: Auto-Retry Pipeline (COMPLETED v0.8.0)
 
-See "Auto-Retry Pipeline" section above. Result: **88% raw → 98% with retry (35/40 → 39/40)**.
+See "Auto-Retry Pipeline" section above. ⚠️ Its effect on pass rate is **unmeasured** — no benchmark exercises it.
 
 ### Phase 5: CTO Mission Orchestrator (IMPLEMENTED Feb 27, 2026)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Status: stable at v0.11.0 (March 2026).** ABCC is the godfather of a family of AI coding-agent experiments I've been building since January 2026. Active development has since moved to newer projects — most notably **[claudette](https://github.com/mrdushidush/claudette)**, a local-first personal-assistant descendant of the same lineage (messaging-app access + voice + persistent scheduler, also on [crates.io](https://crates.io/crates/claudette)). This repo remains online as a reference implementation of the architecture (Campbell complexity routing, tiered Ollama → Claude fallback, RTS-style TUI, Bark military voice lines). Issues and PRs still welcome; don't expect rapid feature work here — that's happening in the successor projects.
 
-> **Run ~98% of C1-C9 coding tasks for FREE on a $300 GPU (with auto-retry; 88% raw single-pass) — including LRU caches and RPN calculators — with Claude handling C10 decomposition at ~$0.002/task average.**
+> **Run 88-98% of C1-C9 coding tasks for FREE on a $300 GPU — including LRU caches and RPN calculators — with Claude handling C10 decomposition at ~$0.002/task average.** Both figures are single-pass runs of the 40-task C1-C9 benchmark: 88% (35/40) on 2026-02-05, 98% (39/40) on 2026-02-20 after context-routing changes. The auto-retry pipeline's contribution is unmeasured.
 
 An RTS-inspired control center for orchestrating AI coding agents with intelligent tiered routing. Watch your AI agents work in real-time with a retro strategy game-style interface.
 
@@ -11,7 +11,7 @@ An RTS-inspired control center for orchestrating AI coding agents with intellige
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/docker-ready-blue.svg)](https://www.docker.com/)
 [![Tests](https://img.shields.io/badge/tests-23%20test%20files-success)](./packages/api/src/__tests__)
-[![Ollama Tested](https://img.shields.io/badge/Ollama%20C1--C9-98%25%20w%2F%20retry%20%E2%80%A2%2088%25%20raw-success)](./scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md)
+[![Ollama Tested](https://img.shields.io/badge/Ollama%20C1--C9-88--98%25%20single--pass-success)](./scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 **If you find this useful, [give it a star](https://github.com/mrdushidush/agent-battle-command-center/stargazers)** — it helps others discover this project and motivates development.
@@ -27,7 +27,7 @@ An RTS-inspired control center for orchestrating AI coding agents with intellige
 **💰 Cost Optimization (20x cheaper than cloud-only)**
 - FREE local execution via Ollama (base `qwen2.5-coder:7b` + routed `:16k` / `:32k` context variants) for C1-C9 tasks
 - Smart tiered routing: only use paid Claude API for C10 multi-class architectural tasks
-- **Proven:** 88% raw / 98% with auto-retry on the 40-task C1-C9 stress benchmark — see [QWEN25_CODER_7B_ULTIMATE_REPORT.md](./scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md)
+- **Measured:** 88% (35/40) and 98% (39/40) on two single-pass runs of the 40-task C1-C9 stress benchmark — see [QWEN25_CODER_7B_ULTIMATE_REPORT.md](./scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md)
 - Passes LRU Cache, RPN Calculator, Sorted Linked List, Stack — all FREE on local GPU
 
 **🎯 Academic Complexity Routing + Per-Agent Model Override**
@@ -223,10 +223,10 @@ For contributors and developers who want to modify the code.
 ## 🎯 Key Features
 
 ### Tiered Task Routing + Per-Agent Model Selection (v0.7.0)
-- **Complexity 1-6** → Ollama with `:16k` context variant (FREE, ~12s avg)
+- **Complexity 1-6** → Ollama with `:16k` context variant (FREE)
 - **Complexity 7-9** → Ollama with `:32k` context variant (FREE) — or Remote Ollama if `REMOTE_OLLAMA_URL` is set
 - **Complexity 10** → Sonnet decomposition (~$0.005/task) — multi-class architectural tasks only
-- **Combined pass rate:** 88% raw / 98% with auto-retry on the 40-task C1-C9 stress benchmark
+- **Combined pass rate:** 88% (35/40) and 98% (39/40) on two single-pass runs of the 40-task C1-C9 stress benchmark
 - **Haiku eliminated** from execution routing — Ollama handles C7-C9; Haiku only escalates failed validations
 - **Per-agent model override** — sidebar dropdown to force any agent to use a specific model
 - **Grok (xAI) support** — set `XAI_API_KEY` to enable Grok as a model option
@@ -416,7 +416,7 @@ curl http://localhost:3001/api/agents/ollama-status \
 node scripts/ollama-stress-test.js
 ```
 
-**40-task ultimate test (C1-C9, 88% raw / 98% with auto-retry, dynamic 16K/32K context):**
+**40-task ultimate test (C1-C9, 88% then 98% single-pass, dynamic context routing):**
 ```bash
 node scripts/ollama-stress-test-40.js
 ```
@@ -681,10 +681,10 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 | Metric | Result | Test |
 |--------|--------|------|
-| **Ollama C1-C9 Success (raw)** | **88% (35/40)** | 40-task ultimate test, dynamic 16K/32K context |
-| **Ollama C1-C9 Success (with auto-retry)** | **98% (39/40)** | Same suite, with validation retry pipeline (v0.5.0+) |
+| **Ollama C1-C9 Success (2026-02-05)** | **88% (35/40)** | 40-task ultimate test, single-pass, no retries |
+| **Ollama C1-C9 Success (2026-02-20)** | **98% (39/40)** | Same suite after context-routing changes, also single-pass |
 | **Ollama C1-C8 Success** | 100% (20/20) | 20-task baseline stress test |
-| **Ollama avg time** | **12s/task** | dynamic 16K/32K context |
+| **Ollama avg time** | 54.4s/task (23s median) | 2026-02-05 run; the 2026-02-20 run averaged 32.7s |
 | **Cost per task (avg)** | $0.002 | Mixed complexity batch |
 | **GPU utilization** | 93% GPU / 7% CPU | 7GB VRAM on RTX 3060 Ti 8GB |
 | **Parallel speedup** | 40-60% | vs sequential |
@@ -722,9 +722,9 @@ Canonical benchmark report: [`scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md`](./scr
 - ✅ **Grok (xAI) support** — new model option for all agents (v0.7.0)
 - ✅ **CTO agents in sidebar** — full visibility for all 3 agent types (v0.7.0)
 - ✅ **3-tier routing** — Local Ollama / Remote Ollama / Claude API (v0.5.1)
-- ✅ **Auto-retry pipeline** — 98% pass rate with validation + retry (v0.5.0)
+- ✅ **Auto-retry pipeline** — validation + tiered retry on failure (v0.5.0); effect on pass rate not yet benchmarked
 - ✅ Tiered task routing (Ollama/Sonnet/Opus)
-- ✅ Dynamic 16K/32K context routing for Ollama — 88% raw / 98% with auto-retry, C1-C9
+- ✅ Dynamic 16K/32K context routing for Ollama — 88% then 98% single-pass, C1-C9
 - ✅ 3D holographic battlefield view with React Three Fiber
 - ✅ Bark TTS military radio voice lines — 96 clips, 3 packs
 - ✅ API authentication and rate limiting


### PR DESCRIPTION
## What

The repo claimed in twelve places across `README.md` and `CLAUDE.md` that the auto-retry pipeline lifts the C1-C9 pass rate from **88% to 98%**. Both numbers are real; the causal link between them is not. This PR reports both runs with their real provenance and drops one unsourced figure.

## Why it is wrong

| | canonical report | the other run |
|---|---|---|
| file | `scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md` | `scripts/ollama-stress-results-40.json` |
| date | 2026-02-05 | 2026-02-20 |
| result | **88% (35/40)** | **98% (39/40)** |
| avg / task | 54.4s (23s median) | 32.7s (`totalDuration` 1307s ÷ 40) |

- The report the README links as canonical contains **zero** occurrences of `98` or `39/40` — `grep -cE '98|39/40'` returns 0. The 98% came from the JSON and was glued onto the report's 88% as if retry explained the gap.
- **Neither run used retry.** `scripts/ollama-stress-test-40.js` creates → assigns → executes → completes → validates each task exactly once. `grep -nE 'retry|Retry|attempt'` over that file returns nothing. What changed between the two runs was context routing.
- **`12s avg/task` is unsourced.** The report says 54.4s avg / 23s median; the JSON works out to 32.7s. No artefact in the repo contains 12s.

## What changed

12 hunks, 2 files — 9 in `README.md` (headline, badge, "Proven" bullet, routing line, combined pass rate, test-command heading, metrics table, two roadmap lines), 3 in `CLAUDE.md` (Auto-Retry Pipeline result, Phase 2 "Best Results", Phase 4 summary).

Both pass rates are **kept**, each labelled with its date and its single-pass status — 98% is a genuine measured result and deleting it would be its own inaccuracy. Where the docs credited auto-retry, they now say its effect on pass rate is **unmeasured**, because no benchmark in the repo exercises it.

Every figure introduced traces to an artefact:

| number | source |
|---|---|
| 88%, 35/40, 54.4s, 23s median | `scripts/QWEN25_CODER_7B_ULTIMATE_REPORT.md:16-19` (dated 2026-02-05) |
| 98%, 39/40 | `scripts/ollama-stress-results-40.json` (`passed: 39`, `successRate: 98`, timestamp 2026-02-20) |
| 32.7s | same JSON, `totalDuration: 1307` ÷ 40 |
| "no retries" | `scripts/ollama-stress-test-40.js:494-545` — one attempt per task |

## Out of scope

`MVP_ASSESSMENT.md` (12 further hits) and `CHANGELOG.md` (3) carry the same claim and are left for a follow-up. A changelog is a historical record — correcting it in place vs. appending a correction is an editorial call, not a find-and-replace.

## Verification

⚠️ **No test power, and none is claimed.** No lint or test step reads prose, so the gate structurally cannot catch a wrong number in a Markdown file — which is exactly how this claim reached six files. Verification is:

1. Acceptance greps — all three return empty:
   ```
   grep -nE '88% raw|with auto-retry|12s avg|12s/task' README.md CLAUDE.md
   grep -nE '35/40 → 39/40|39/40\)\*\* C1-C9' README.md CLAUDE.md
   grep -n '~12s' README.md
   ```
2. Reading the diff — 12 hunks, no more.
3. Each figure traced to its artefact (table above), re-verified independently rather than taken from the spec.

Gate, unchanged from `main` @ `836f90d`:

| | before | after |
|---|---|---|
| `corepack pnpm -r lint` | rc 0 | rc 0 |
| `@abcc/api` tests | 251 / 17 suites | 251 / 17 suites |
| `@abcc/ui` tests | 53 / 5 files | 53 / 5 files |
| `corepack pnpm -r build` | rc 0 | rc 0 |

`git diff --stat` is exactly `2 files changed, 14 insertions(+), 14 deletions(-)` and is byte-identical under `--ignore-cr-at-eol`; both files remain LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
