### PR TITLE
test(ui): make the five inert vi.mock() calls actually bind

### DIFF
--- a/packages/ui/src/components/AgentCard.test.tsx
+++ b/packages/ui/src/components/AgentCard.test.tsx
@@ -4,7 +4,7 @@ import { mockAgent } from '../test/utils';
 import { AgentCard } from './shared/AgentCard';
 
 // Mock the store and hooks
-vi.mock('../../store/uiState', () => ({
+vi.mock('../store/uiState', () => ({
   useUIStore: () => ({
     selectedAgentId: null,
     selectAgent: vi.fn(),
@@ -12,7 +12,7 @@ vi.mock('../../store/uiState', () => ({
   }),
 }));
 
-vi.mock('../../hooks/useAgents', () => ({
+vi.mock('../hooks/useAgents', () => ({
   useAgents: () => ({
     pauseAgent: vi.fn(),
     resumeAgent: vi.fn(),

--- a/packages/ui/src/components/TaskCard.test.tsx
+++ b/packages/ui/src/components/TaskCard.test.tsx
@@ -4,22 +4,23 @@ import { mockTask } from '../test/utils';
 import { TaskCard } from './shared/TaskCard';
 
 // Mock the store and hooks
-vi.mock('../../store/uiState', () => ({
+vi.mock('../store/uiState', () => ({
   useUIStore: () => ({
     selectedTaskId: null,
     selectTask: vi.fn(),
     agents: [],
     agentHealth: {},
+    validationStatus: {},
   }),
 }));
 
-vi.mock('../../hooks/useTasks', () => ({
+vi.mock('../hooks/useTasks', () => ({
   useTasks: () => ({
     deleteTask: vi.fn(),
   }),
 }));
 
-vi.mock('../../api/client', () => ({
+vi.mock('../api/client', () => ({
   executeApi: vi.fn(),
 }));
 


### PR DESCRIPTION
## What

The five `vi.mock()` factories in `AgentCard.test.tsx` and `TaskCard.test.tsx` have never applied. This fixes their specifiers and adds the one mock field that fixing them exposes.

## Why

Both test files live in `packages/ui/src/components/`; the components they test live one level deeper in `packages/ui/src/components/shared/`. The specifiers were copied verbatim out of the components — where `'../../store/uiState'` correctly means `src/store/uiState` — into the test files, where the same string means `packages/ui/store/uiState`.

That directory does not exist, and neither does `packages/ui/hooks` or `packages/ui/api`. `vi.mock()` on a specifier that never matches a real import is a silent no-op, so both suites have been running against the **real** store, the **real** `useTasks`/`useAgents` hooks and the **real** `api/client` — passing only because those modules happen to tolerate it.

## Not a pure find-and-replace

Fixing the paths alone turns the suite **red**. Once the store mock binds, `shared/TaskCard.tsx:43` destructures `validationStatus` and line 388 does `validationStatus[task.id]` → `undefined['test-task-1']`, failing 10 of 53 tests. So hunk 3 ships the path fix **and** `validationStatus: {}` as one block; splitting them reintroduces the failure.

`AgentCard` is deliberately left path-only — `shared/AgentCard.tsx` does not read `validationStatus`.

## Power check — every row was run, not predicted

| state | `@abcc/ui` |
|---|---|
| pre-fix paths, factory gutted to `() => ({})` | **53 passed** — an empty mock is indistinguishable from the fixture, because neither binds |
| fixed paths, `validationStatus` **not** added | **10 failed / 43 passed** — the mock now binds |
| as shipped | **53 passed**, mocks bound |

The first row is the real argument for this PR: today you can put anything — or nothing — in those factories and the suite stays green.

## Scope

⚠️ **This adds no coverage and does not claim to.** It repairs test *isolation*; the count stays at 53 deliberately. What changes is what those 53 tests exercise.

## Verified

- `corepack pnpm -r lint` → exit 0
- `corepack pnpm -r --workspace-concurrency=1 test` → api **251/251** in 17 suites, ui **53/53** in 5 files — both unchanged from `main`
- `corepack pnpm -r build` → exit 0
- `git diff --stat` → `2 files changed, 6 insertions(+), 5 deletions(-)`, byte-identical under `--ignore-cr-at-eol`; both files remain LF
- Acceptance grep for any remaining `vi.mock('../../` in the two files → empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
