### PR TITLE
ci: run the @abcc/ui test suite in the Unit Tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
           NODE_ENV: test
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/abcc_test?schema=public
 
+      - name: Run UI unit tests
+        run: pnpm --filter @abcc/ui test
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## What

Adds one step to the `Unit Tests` job so the `@abcc/ui` suite runs in CI.

```yaml
      - name: Run UI unit tests
        run: pnpm --filter @abcc/ui test
```

`1 file changed, 3 insertions(+)`. No application code, no test changes, no lockfile.

## Why

`ci.yml:98` is `pnpm --filter @abcc/api test`, and grepping the workflow for `filter @abcc/ui test`
returned nothing. **The UI suite has never run in CI.** The 53 tests in
`packages/ui/src/components` are a local-only measurement — a PR could break or delete all 53 and
all six checks would still go green. The last two merges did exactly that: fully green, UI never run.

Prerequisites are already met upstream in the same job — line 89 installs `--frozen-lockfile`,
line 92 builds `@abcc/shared` (which `@abcc/ui` depends on).

**Separate step, not a second `--filter` on line 98:** the existing step carries `NODE_ENV=test`
and a `DATABASE_URL`. The UI suite is vitest + jsdom and needs neither, and folding them together
would merge two unrelated failures into one log line.

## Power check — does the step actually catch anything?

The suite had never once executed on Linux, so it was run there *before* this change was written:
`git archive HEAD` into a `node:20` container, then the job's own steps in the job's own order
(install → build shared → `db:generate` → tests). Every row was run, not predicted.

| | api filter (**CI today**) | ui filter (**this PR**) |
|---|---|---|
| clean tree | 251/251, 17 suites, **rc 0** | 53/53, 5 files, **rc 0** |
| `shared/StatusBadge.tsx` label `'In Progress'` → `'In-Progress'` | 251/251, **rc 0** — green on a broken UI | **1 failed / 52 passed, rc 1** |

The failing row names it precisely:

```
FAIL  src/components/StatusBadge.test.tsx > StatusBadge > Task Status Badges > should render in_progress status
TestingLibraryElementError: Unable to find an element with the text: In Progress
```

Mutation reverted, file restored byte-identical.

## Hazards checked rather than assumed

1. **jsdom / no display** — `vite.config.ts` sets `environment: 'jsdom'`; `jsdom@28.1.0` is in the
   lockfile. Pure JS, no display server. Confirmed by the container run.
2. **Case-sensitive filesystem** — `packages/ui/tsconfig.json` *excludes* `src/**/*.test.tsx` and
   `src/test`, so `pnpm -r lint` never typechecks the test files and a casing error would survive
   the lint gate and break only on Linux. All six relative imports in the five test files were
   compared against `git ls-files` casing: exact. Confirmed by the container run.
3. **vitest watch mode** — `package.json` maps `test` to `vitest run`, not bare `vitest`.

Environment parity: node **v20.20.2** (`NODE_VERSION: "20"`), pnpm **10.34.5**
(`PNPM_VERSION: "10"`), `--frozen-lockfile` → *"Lockfile is up to date, resolution step is skipped"*.

## Gate (local, on this branch)

| | result |
|---|---|
| `corepack pnpm -r lint` | rc 0 |
| `@abcc/api` | **251 passed, 17 suites** |
| `@abcc/ui` | **53 passed, 5 files** |
| `corepack pnpm -r build` | rc 0 |

Unchanged from `main`, as a CI-config card must be. Diff is identical under
`--ignore-cr-at-eol`; the file remains LF.

## Known gap, deliberately out of scope

Hazard 2 above means UI test files are not type-checked by the `lint` gate at all. That is real,
but it is a different change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
