### PR TITLE
test(ui): typecheck the UI test files and align the fixtures to @abcc/shared

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/ui/src/components/AgentCard.test.tsx
+++ b/packages/ui/src/components/AgentCard.test.tsx
@@ -72,14 +72,14 @@ describe('AgentCard', () => {
 
   describe('Agent Types', () => {
     it('should render coder agent', () => {
-      const coderAgent = { ...mockAgent, type: 'coder', agentType: { ...mockAgent.agentType, name: 'coder' } };
-      render(<AgentCard agent={coderAgent as any} />);
+      const coderAgent = { ...mockAgent, type: 'coder' as const };
+      render(<AgentCard agent={coderAgent} />);
       expect(screen.getByText('Test Agent')).toBeInTheDocument();
     });
 
     it('should render qa agent', () => {
-      const qaAgent = { ...mockAgent, type: 'qa', agentType: { ...mockAgent.agentType, name: 'qa' } };
-      render(<AgentCard agent={qaAgent as any} />);
+      const qaAgent = { ...mockAgent, type: 'qa' as const };
+      render(<AgentCard agent={qaAgent} />);
       expect(screen.getByText('Test Agent')).toBeInTheDocument();
     });
   });
@@ -107,15 +107,15 @@ describe('AgentCard', () => {
 
   describe('Agent Colors', () => {
     it('should apply coder color scheme', () => {
-      const coderAgent = { ...mockAgent, type: 'coder', agentType: { ...mockAgent.agentType, name: 'coder' } };
-      const { container } = render(<AgentCard agent={coderAgent as any} />);
+      const coderAgent = { ...mockAgent, type: 'coder' as const };
+      const { container } = render(<AgentCard agent={coderAgent} />);
       const icon = container.querySelector('.text-agent-coder');
       expect(icon).toBeInTheDocument();
     });
 
     it('should apply qa color scheme', () => {
-      const qaAgent = { ...mockAgent, type: 'qa', agentType: { ...mockAgent.agentType, name: 'qa' } };
-      const { container } = render(<AgentCard agent={qaAgent as any} />);
+      const qaAgent = { ...mockAgent, type: 'qa' as const };
+      const { container } = render(<AgentCard agent={qaAgent} />);
       const icon = container.querySelector('.text-agent-qa');
       expect(icon).toBeInTheDocument();
     });

--- a/packages/ui/src/components/ErrorBoundary.test.tsx
+++ b/packages/ui/src/components/ErrorBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { render, screen } from '../test/utils';
 import { ErrorBoundary } from './ErrorBoundary';
 

--- a/packages/ui/src/components/TaskCard.test.tsx
+++ b/packages/ui/src/components/TaskCard.test.tsx
@@ -43,7 +43,7 @@ describe('TaskCard', () => {
     });
 
     it('should render priority level', () => {
-      const highPriorityTask = { ...mockTask, priority: 9 };
+      const highPriorityTask = { ...mockTask, priority: 9 as const };
       render(<TaskCard task={highPriorityTask} />);
       expect(screen.getByText('P9')).toBeInTheDocument();
     });
@@ -51,19 +51,19 @@ describe('TaskCard', () => {
 
   describe('Priority Levels', () => {
     it('should show high priority for priority >= 8', () => {
-      const { container } = render(<TaskCard task={{ ...mockTask, priority: 8 }} />);
+      render(<TaskCard task={{ ...mockTask, priority: 8 }} />);
       const priorityBadge = screen.getByText('P8').closest('span');
       expect(priorityBadge).toHaveClass('bg-hud-red/20', 'text-hud-red');
     });
 
     it('should show medium priority for priority 5-7', () => {
-      const { container } = render(<TaskCard task={{ ...mockTask, priority: 6 }} />);
+      render(<TaskCard task={{ ...mockTask, priority: 6 }} />);
       const priorityBadge = screen.getByText('P6').closest('span');
       expect(priorityBadge).toHaveClass('bg-hud-amber/20', 'text-hud-amber');
     });
 
     it('should show low priority for priority < 5', () => {
-      const { container } = render(<TaskCard task={{ ...mockTask, priority: 3 }} />);
+      render(<TaskCard task={{ ...mockTask, priority: 3 }} />);
       const priorityBadge = screen.getByText('P3').closest('span');
       expect(priorityBadge).toHaveClass('bg-gray-500/20', 'text-gray-400');
     });
@@ -103,7 +103,7 @@ describe('TaskCard', () => {
       const onClick = vi.fn();
       render(<TaskCard task={mockTask} onClick={onClick} />);
 
-      const card = screen.getByText('Test Task').closest('.task-card');
+      const card = screen.getByText('Test Task').closest<HTMLElement>('.task-card');
       card?.click();
 
       expect(onClick).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/test/utils.tsx
+++ b/packages/ui/src/test/utils.tsx
@@ -1,6 +1,7 @@
 import { render, RenderOptions } from '@testing-library/react';
 import { ReactElement } from 'react';
 import { vi } from 'vitest';
+import type { Agent, Task } from '@abcc/shared';
 
 /**
  * Custom render function that wraps components with necessary providers
@@ -15,65 +16,55 @@ export function renderWithProviders(
 /**
  * Mock task data for testing
  */
-export const mockTask = {
+export const mockTask: Task = {
   id: 'test-task-1',
   title: 'Test Task',
   description: 'Test task description',
-  taskType: 'code' as const,
-  status: 'pending' as const,
-  priority: 5,
-  complexity: 5,
-  routerComplexity: 5,
-  haikuComplexity: null,
-  finalComplexity: 5,
+  taskType: 'code',
   requiredAgent: null,
+  status: 'pending',
+  priority: 5,
+  maxIterations: 3,
+  currentIteration: 0,
   assignedAgentId: null,
   assignedAt: null,
-  currentIteration: 0,
-  maxIterations: 3,
+  needsHumanAt: null,
+  humanTimeoutMinutes: 30,
+  escalatedToAgentId: null,
   result: null,
   error: null,
-  errorCategory: null,
+  metrics: {
+    apiCreditsUsed: 0,
+    timeSpentMs: 0,
+    iterations: 0,
+  },
   lockedFiles: [],
-  acceptanceCriteria: null,
-  contextNotes: null,
-  validationCommand: null,
-  humanTimeoutMinutes: 30,
   parentTaskId: null,
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
-  timeSpentMs: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
   completedAt: null,
-  apiCreditsUsed: 0,
 };
 
 /**
  * Mock agent data for testing
  */
-export const mockAgent = {
+export const mockAgent: Agent = {
   id: 'test-agent-1',
-  name: 'Test Agent',
   agentTypeId: 'coder',
-  status: 'idle' as const,
+  type: 'coder',
+  name: 'Test Agent',
+  status: 'idle',
   currentTaskId: null,
+  config: {},
   stats: {
     tasksCompleted: 10,
     tasksFailed: 2,
-    totalIterations: 15,
-    avgIterations: 1.5,
-    totalTimeMs: 120000,
-    avgTimeMs: 12000,
     successRate: 0.83,
+    totalApiCredits: 1.5,
+    totalTimeMs: 120000,
   },
-  config: {},
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
-  agentType: {
-    id: 'coder',
-    name: 'coder',
-    description: 'Coding agent',
-    capabilities: ['file_write', 'code_generation'],
-  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
 };
 
 /**

--- a/packages/ui/tsconfig.test.json
+++ b/packages/ui/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

`packages/ui/tsconfig.json` excludes `src/**/*.test.tsx`, `src/**/*.test.ts` and `src/test`, so
`corepack pnpm -r lint` (= `tsc --noEmit`) **has never typechecked a single UI test file.**

This adds a `tsconfig.test.json` wired into the lint script, and fixes the 28 errors that turning
it on reports.

`6 files changed, 46 insertions(+), 50 deletions(-)`. No application code, no test count change,
no lockfile.

## The drift it uncovered

Unchecked, the two shared fixtures in `src/test/utils.tsx` had drifted from the types they stand
in for:

| | `mockTask` vs `Task` | `mockAgent` vs `Agent` |
|---|---|---|
| missing | `needsHumanAt`, `escalatedToAgentId`, `metrics` | `type`, `stats.totalApiCredits` |
| wrong type | `createdAt`/`updatedAt` were `string`, not `Date`; `validationCommand: null` vs optional `string` | — |
| undeclared extras | 9 fields (`complexity`, `routerComplexity`, `errorCategory`, …) | `agentType` object; `stats.totalIterations`/`avgIterations`/`avgTimeMs` |

Both fixtures are now annotated `: Task` and `: Agent`, so they can't drift again without failing
the gate.

**Nothing under test loses anything** — checked by grep, not assumed. `shared/TaskCard.tsx` reads
11 task fields and `shared/AgentCard.tsx` reads 7 agent fields, all declared on the shared types,
and of `stats` only `successRate` and `tasksCompleted`. The flat `timeSpentMs`/`apiCreditsUsed` are
superseded by `metrics`, which is what `TaskDetail.tsx` actually reads.

⚠️ The four `as any` casts in `AgentCard.test.tsx` are removed on purpose — they were what let the
broken fixture through.

## Why a separate tsconfig, not deleting the exclude

`build` is `tsc && vite build` against that same tsconfig. Dropping the `exclude` would let a type
error in a test **block a deployable production build**. As shipped, a broken test type fails lint
and CI, and nothing else.

## Power check

Every row run, not predicted. `old lint` = today's `tsc --noEmit` (production project only).

| injected fault | old lint | **new lint** | vitest |
|---|---|---|---|
| `mockTask.priority: 5` → `'high'` | PASS (missed) | **FAIL (caught)** | PASS (missed) |
| `mockTask` loses required `metrics` | PASS (missed) | **FAIL (caught)** | PASS (missed) |
| `mockAgent.type` → `'designer'` (not an `AgentType`) | PASS (missed) | **FAIL (caught)** | PASS (missed) |
| `TaskCard.test` passes a non-existent prop | PASS (missed) | **FAIL (caught)** | PASS (missed) |

**4/4 caught by the new lint; 0/4 caught by anything that exists today** — not the old lint, and
not the test suite either. All files restored byte-identical after the run.

That last column is the point: these aren't faults the tests were covering from another angle.
Before this, nothing in the repo could see them at all.

## Gate

| | result |
|---|---|
| `corepack pnpm -r lint` | rc 0 — `@abcc/ui` now runs **two** `tsc` passes |
| `@abcc/api` | **251 passed, 17 suites** |
| `@abcc/ui` | **53 passed, 5 files** |
| `corepack pnpm -r build` | rc 0 |

Test counts unchanged. All 53 UI tests still pass with real `Date` objects in the fixtures — that
was measured, not assumed.

⚠️ Three of the six files were CRLF in the working tree and LF in the blob (git's stat cache hides
this) and were normalised before the change. Without that, this diff would have been an
unreviewable full rewrite of `utils.tsx`. The diff is identical under `--ignore-cr-at-eol` and all
six files are LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
