### PR TITLE
ci: bump the five Node-20 GitHub Actions to their Node-24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -47,12 +47,12 @@ jobs:
         run: pnpm lint
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('packages/agents/requirements.txt') }}
@@ -72,15 +72,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -104,12 +104,12 @@ jobs:
         run: pnpm --filter @abcc/ui test
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('packages/agents/requirements.txt') }}
@@ -135,15 +135,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -167,7 +167,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -213,15 +213,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Every job on `main` emits a deprecation warning. Run [31014547252](https://github.com/mrdushidush/agent-battle-command-center/actions/runs/31014547252) on `6264d11` carries it on **Lint & Type Check**, **Unit Tests** and **Build**:

> `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4, actions/setup-node@v4, actions/setup-python@v5, pnpm/action-setup@v3.`

Read precisely, that is about **the actions' own JavaScript runtime**, not this project's `NODE_VERSION: "20"` (`ci.yml:10`), which is a separate deliberate choice and is **unchanged here**. GitHub is force-upgrading those five runtimes today and will drop the shim later, at which point CI breaks rather than warns.

## The change — 18 one-line edits across 2 files

| action | from | to | tag resolves to | sites |
|---|---|---|---|---|
| `actions/checkout` | `@v4` | `@v7` | v7.0.1, 2026-07-17 | 5 ci + 1 publish |
| `pnpm/action-setup` | `@v3` | `@v6` | v6.0.10, 2026-08-03 | 4 ci |
| `actions/setup-node` | `@v4` | `@v7` | v7.0.0, 2026-07-14 | 4 ci |
| `actions/setup-python` | `@v5` | `@v7` | v7.0.0, 2026-07-20 | 2 ci |
| `actions/cache` | `@v4` | `@v6` | v6.1.0, 2026-06-23 | 2 ci |

Each moves to a **bare major**, matching the convention every ref in both files already uses, so they keep receiving patch and security fixes without another commit. All five moving major tags were confirmed to exist and resolve to the current release before the change was written.

## Why Dependabot never proposed these

`.github/dependabot.yml:12-14` sets `ignore: dependency-name "*"` / `update-types: ["version-update:semver-major"]` for the `github-actions` ecosystem. The weekly Monday scan is **structurally incapable** of opening any of these PRs — which is why the five are 2-3 majors stale. That rule is worth revisiting, but it is a policy question about a different file and is left alone here.

## "Mechanical" was the pitch, not the finding

These cross 2-3 majors each, so every release note between old and new pin was read. Four plausible breaks, all checked rather than assumed:

1. **`pnpm/action-setup@v4.0.0`** throws when `package.json`'s `packageManager` field names a different pnpm version than the action's settings. **Inert** — no `package.json` here has that field (root + all four packages), so `version: ${{ env.PNPM_VERSION }}` stays required and correct.
2. **`setup-node@v5.0.0`** added automatic caching driven by that same field, and **`@v6.0.0`** then *limited automatic caching to npm*. **Inert, and the one worth being precise about** — both govern the *automatic* `package-manager-cache` input. These workflows set the **explicit** `cache: "pnpm"`, which the **v7.0.0 `action.yml` still documents as taking `npm, yarn, pnpm`**. Verified by reading `action.yml` at the v7.0.0 tag, not by inferring from release notes.
3. **`setup-python@v7.0.0`** removes the `pip-install` input. **Inert** — neither step passes anything but `python-version`.
4. **`checkout@v7.0.0`** blocks fork-PR checkout for `pull_request_target` / `workflow_run`. **Inert** — neither appears in the repo; `ci.yml` triggers on `push`/`pull_request`, `docker-publish.yml` on `release`.

Four of the new majors require Actions Runner ≥ 2.327.1, which only constrains self-hosted runners; both workflows use `ubuntu-latest`.

## Deliberately out of scope

Untouched because the warning does not name them and they carry risk this change does not — they belong in their own PR:

`docker/build-push-action@v5` (×6), `docker/setup-buildx-action@v3` (×2), `docker/login-action@v3`, and `aquasecurity/trivy-action@master` (branch-pinned). These touch the image-publish path and the security gate. `github/codeql-action/upload-sarif` is already current at `v4.37.4`.

## Verification

`corepack pnpm -r lint` exit 0 · api **251/251 in 17 suites** · ui **53/53 in 5 files** · `-r build` exit 0 — all unchanged from `main`, as a CI-config-only change must leave them.

`git diff --stat` is exactly **2 files changed, 18 insertions(+), 18 deletions(-)**, identical under `--ignore-cr-at-eol`; both files remain LF at 0 CRLF. Line counts unchanged (256 / 97). Both post-edit files were parsed with a YAML parser: `ci.yml` still 5 jobs / 41 steps / 23 `uses` refs, `docker-publish.yml` still 1 job / 8 steps / 6 refs. Grep for the five old refs returns nothing; `docker/build-push-action@v5` still counts 3 and 3.

⚠️ The local gate **cannot** exercise this change — it was run to prove nothing else broke. **The real acceptance test is CI on this PR**, and specifically that the Node 20 deprecation warning is gone from every job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)