### PR TITLE
fix(api): make the failed-task retry branch actually retry, and release what it held

### DIFF
--- a/packages/api/src/services/__tests__/taskQueue.test.ts
+++ b/packages/api/src/services/__tests__/taskQueue.test.ts
@@ -1,5 +1,6 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { TaskQueueService } from '../taskQueue.js';
+import { ResourcePoolService } from '../resourcePool.js';
 import { prismaMock } from '../../__mocks__/prisma.js';
 import type { Server as SocketIOServer } from 'socket.io';
 import type { Task, Agent, AgentType as PrismaAgentType, FileLock } from '@prisma/client';
@@ -334,29 +335,79 @@ describe('TaskQueueService', () => {
   });
 
   describe('handleTaskFailure', () => {
-    it('should retry if under max iterations', async () => {
+    it('should return the task to the pending queue if under max iterations', async () => {
       const task = createTask({
         status: 'in_progress',
         assignedAgentId: 'agent-1',
         currentIteration: 1,
         maxIterations: 3,
       });
-      const updatedTask = { ...task, status: 'assigned', error: 'Test error' };
+      const agent = createAgent({ id: 'agent-1', status: 'busy', currentTaskId: 'task-1' });
+      const updatedTask = { ...task, status: 'pending', assignedAgentId: null, error: 'Test error' };
 
       prismaMock.task.findUnique.mockResolvedValue(task);
       prismaMock.taskExecution.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.fileLock.deleteMany.mockResolvedValue({ count: 0 });
       prismaMock.task.update.mockResolvedValue(updatedTask);
+      prismaMock.task.findMany.mockResolvedValue([]);
+      prismaMock.agent.findUnique.mockResolvedValue(agent);
+      prismaMock.agent.update.mockResolvedValue({ ...agent, status: 'idle', currentTaskId: null });
 
       await service.handleTaskFailure('task-1', 'Test error');
 
+      // 'pending', not 'assigned': autoAssignNextTask selects on status 'pending',
+      // so an 'assigned' task is picked up by nothing and never actually retried.
       expect(prismaMock.task.update).toHaveBeenCalledWith({
         where: { id: 'task-1' },
         data: {
-          status: 'assigned',
+          status: 'pending',
+          assignedAgentId: null,
+          assignedAt: null,
           error: 'Test error',
         },
       });
-    });
+      // 15s timeout: releasing the agent applies the Ollama rest delay, which is
+      // 3s and 8s on every 5th call, counted in a module-level map shared by the
+      // whole file. The generous timeout keeps this deterministic either way.
+    }, 15000);
+
+    it('should release the file locks, the resource slot and the agent when retrying', async () => {
+      const task = createTask({
+        status: 'in_progress',
+        assignedAgentId: 'agent-1',
+        currentIteration: 1,
+        maxIterations: 3,
+      });
+      const agent = createAgent({ id: 'agent-1', status: 'busy', currentTaskId: 'task-1' });
+
+      prismaMock.task.findUnique.mockResolvedValue(task);
+      prismaMock.taskExecution.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.fileLock.deleteMany.mockResolvedValue({ count: 0 });
+      prismaMock.task.update.mockResolvedValue({ ...task, status: 'pending' });
+      prismaMock.task.findMany.mockResolvedValue([]);
+      prismaMock.agent.findUnique.mockResolvedValue(agent);
+      prismaMock.agent.update.mockResolvedValue({ ...agent, status: 'idle', currentTaskId: null });
+
+      const resourcePool = ResourcePoolService.getInstance();
+      resourcePool.acquire('ollama', 'task-1');
+      expect(resourcePool.getTaskResource('task-1')).toBe('ollama');
+
+      await service.handleTaskFailure('task-1', 'Test error');
+
+      // Each of these was held by the failed attempt and leaked before the fix:
+      // the Ollama slot stayed occupied and coder-01 stayed busy until a human
+      // hit the reset button, because only forceRecoverAll() covers 'assigned'.
+      expect(resourcePool.getTaskResource('task-1')).toBeNull();
+      expect(prismaMock.fileLock.deleteMany).toHaveBeenCalledWith({
+        where: { lockedByTask: 'task-1' },
+      });
+      expect(prismaMock.agent.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'agent-1' },
+          data: expect.objectContaining({ status: 'idle', currentTaskId: null }),
+        })
+      );
+    }, 15000);
 
     it('should abort if max iterations reached', async () => {
       const task = createTask({

--- a/packages/api/src/services/taskExecutor.ts
+++ b/packages/api/src/services/taskExecutor.ts
@@ -241,16 +241,35 @@ export class TaskExecutor {
     }
 
     if (task.currentIteration < task.maxIterations) {
-      // Retry: return to assigned state for retry
+      // Retry: release everything this attempt held, then return the task to the
+      // pending queue. Nothing polls 'assigned' - autoAssignNextTask selects on
+      // status 'pending' - so leaving the task assigned held the agent, the
+      // resource-pool slot and the file locks until a human hit reset, and the
+      // retry never actually happened. currentIteration is deliberately kept so
+      // the next attempt still counts towards maxIterations.
+      await this.taskAssigner.releaseFileLocks(taskId);
+
+      const resourcePool = ResourcePoolService.getInstance();
+      const retryResourceType = resourcePool.getTaskResource(taskId);
+      resourcePool.release(taskId);
+
       const updatedTask = await this.prisma.task.update({
         where: { id: taskId },
         data: {
-          status: 'assigned',
+          status: 'pending',
+          assignedAgentId: null,
+          assignedAt: null,
           error,
         },
       });
 
       this.emitTaskUpdate(updatedTask as unknown as Task);
+
+      // Frees the agent and triggers auto-assign, which picks the task back up.
+      // Must run after the task is pending or auto-assign cannot see it.
+      if (task.assignedAgentId) {
+        await this.updateAgentOnFailure(task.assignedAgentId, task.complexity || 5, retryResourceType || undefined);
+      }
     } else {
       // Max iterations reached: mark as failed
       await this.abortTask(taskId, error);


### PR DESCRIPTION
`handleTaskFailure` has two branches. The max-iterations branch calls `abortTask`, which releases **three** things: the file locks, the resource-pool slot, and the agent. The retry branch at `taskExecutor.ts:243-253` released **none** of them — it set the task to `'assigned'` and returned.

Two things were wrong with that, and the second is worse than the first.

### 1. It leaked

The agent stayed `busy` with `currentTaskId` set, the pool slot stayed occupied, the file locks stayed held. On the default single-slot Ollama pool that wedges **`coder-01` and the only Ollama slot at once**.

Recovery was not absent, but it was **manual-only**: the periodic scan (`stuckTaskRecovery.ts:191-194`) selects `status: 'in_progress'` and never sees this task. `'assigned'` is covered solely by `forceRecoverAll()` (`:126-133`) — the reset button / `POST /api/agents/reset-all`. So it stayed wedged until a human noticed.

### 2. The retry never happened — this is the worse half

`autoAssignNextTask` selects on `status: 'pending'` (`taskExecutor.ts:659`). **Nothing anywhere polls `'assigned'` to execute it.** A task under `maxIterations` was not retried later; it was not retried at all. The branch named "retry" parked the task permanently and took the agent with it.

## The fix

Release the file locks and the pool slot, set the task back to `'pending'` with the agent cleared, then call `updateAgentOnFailure` — which frees the agent *and* triggers auto-assign, so the task is genuinely picked back up.

Four deliberate details:

- **`currentIteration` is not reset.** `returnToPool` zeroes it; doing that here would mean `maxIterations` is never reached and the task retries forever. `handleTaskStart` increments it on the next attempt, so the count still climbs to `abortTask`.
- **`getTaskResource` is read before `release`.** Afterwards the pool no longer knows the type, and `updateAgentOnFailure` needs it for the rest-delay decision. Same ordering `abortTask` uses.
- **`updateAgentOnFailure` runs after the task is `'pending'`.** It triggers auto-assign, and auto-assign queries for pending tasks — this ordering is what makes the retry work at all.
- **`updateAgentOnFailure` is reused, not hand-rolled.** It is what `abortTask` calls, and it applies the Ollama rest delay — wanted here, since a retry *is* the next consecutive attempt on the same agent, and that delay exists to stop context pollution between consecutive Ollama tasks.

## The replaced test

The existing test asserted `status: 'assigned'` — the bug written down as an expectation — so it is replaced, not kept. It is the **only** test that pinned this behaviour; the other `'assigned'` occurrences in `taskQueue.test.ts` / `taskAssigner.test.ts` concern task *assignment* and are untouched.

Two tests replace it: one pinning the pending-queue hand-off, one pinning all three releases — the latter **acquiring a real Ollama slot from the resource pool** so the release is observed rather than assumed. Both carry a 15s timeout because releasing the agent applies the real rest delay (3s, and 8s on every 5th call, counted in a module-level map shared by the whole file).

## Power check — fault injection

A behavioural fix has no revert to measure, so the argument is injection:

| source | tests | result |
|---|---|---|
| **buggy (`main`)** | **existing suite** | **251 / 251 pass** — the bug is completely invisible |
| **buggy (`main`)** | the two new tests | **2 failed / 250 passed** — both fire |
| fixed (this PR) | the two new tests | 252 / 252 pass |

The first row is the whole argument: the entire pre-existing suite goes green on a bug that wedges `coder-01` and the only Ollama slot until a human intervenes. After injection the source was restored and confirmed **byte-identical** by sha256.

## Verification

`corepack pnpm -r lint` exit 0 · api **252/252 in 17 suites** · ui **53/53 in 5 files** · `-r build` exit 0.

⚠️ The api count moves **251 → 252** because one test is replaced by two — that is expected for this change, not a stray test.

`git diff --stat` is exactly **2 files changed, 76 insertions(+), 6 deletions(-)**, identical under `--ignore-cr-at-eol`; both files remain LF. The 8 `Cannot log after tests are done` warnings the api suite prints were measured at **8 before and 8 after** — pre-existing and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)